### PR TITLE
Fixed history cannot back to home page

### DIFF
--- a/frontend/src/components/home/CourseCard/CourseCard.tsx
+++ b/frontend/src/components/home/CourseCard/CourseCard.tsx
@@ -22,7 +22,7 @@ const CourseCard: FC<CourseCardProps> = ({ course, user }) => {
   return (
     <Card variant="outlined" sx={{ ':hover': { boxShadow: 2 } }}>
       <ButtonBase
-        onClick={() => router.push("/course/" + course.ID)}
+        onClick={() => router.push(`/course/${course.ID}?view=home`)}
         sx={{ width: "100%", textAlign: "left" }}
         focusRipple
       >


### PR DESCRIPTION
- Closes #99 
- Router must push `view=home` (or any view) when `CourseCard` is clicked